### PR TITLE
Change EquipmentItems index page tables into livewire tables

### DIFF
--- a/app/Http/Controllers/Backend/EquipmentItemController.php
+++ b/app/Http/Controllers/Backend/EquipmentItemController.php
@@ -23,8 +23,8 @@ class EquipmentItemController extends Controller
      */
     public function index()
     {
-        $equipment = EquipmentItem::orderBy('id', 'asc')->paginate(16);
-        return view('backend.equipment.items.index', compact('equipment'));
+        //$equipment = EquipmentItem::orderBy('id', 'asc')->paginate(16);
+        return view('backend.equipment.items.index');
     }
 
     /**

--- a/app/Http/Controllers/Backend/SearchController.php
+++ b/app/Http/Controllers/Backend/SearchController.php
@@ -49,7 +49,7 @@ class SearchController extends Controller
         // For now, only support upto 4 levels
         // I think we can just extend this to like 10 levels or something like that ¯\_(ツ)_/¯
         foreach ($loc as $key => $value) {
-            $locations[$key] = $value->location;
+            $locations[$value->id] = $value->location;
             // Level 2
             if ($value->getChildrenLocations()->count() > 0) {
                 foreach ($value->getChildrenLocations() as $l) {

--- a/app/Http/Livewire/Backend/EquipmentItemTable.php
+++ b/app/Http/Livewire/Backend/EquipmentItemTable.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Livewire\Backend;
+
+use App\Models\EquipmentItem;
+use Illuminate\Database\Eloquent\Builder;
+use Rappasoft\LaravelLivewireTables\DataTableComponent;
+use Rappasoft\LaravelLivewireTables\Views\Column;
+use App\Models\ConsumableItem;
+
+class EquipmentItemTable extends DataTableComponent
+{
+
+    public function columns(): array
+    {
+        return [
+            Column::make("Code")
+                ->sortable(),
+            Column::make("Title", 'title')
+                ->sortable()
+                ->searchable(),
+            Column::make("Product Code and Brand"),
+            Column::make("Quantity", 'quantity')
+                ->sortable(),
+            Column::make("Category"),
+            Column::make("Price (LKR)", 'price')
+                ->sortable(),
+            Column::make("Dimensions(cm) WxLxH"),
+            Column::make("Weight (g)", "weight")
+                ->sortable(),
+            Column::make("Actions")
+        ];
+    }
+
+    public function query(): Builder
+    {
+        return EquipmentItem::query();
+    }
+
+    public function rowView(): string
+    {
+        return 'backend.equipment.items.index-table-row';
+    }
+}

--- a/app/Http/Livewire/Backend/EquipmentItemTable.php
+++ b/app/Http/Livewire/Backend/EquipmentItemTable.php
@@ -3,10 +3,13 @@
 namespace App\Http\Livewire\Backend;
 
 use App\Models\EquipmentItem;
+use App\Models\EquipmentType;
 use Illuminate\Database\Eloquent\Builder;
 use Rappasoft\LaravelLivewireTables\DataTableComponent;
 use Rappasoft\LaravelLivewireTables\Views\Column;
 use App\Models\ConsumableItem;
+use Rappasoft\LaravelLivewireTables\Views\Filter;
+use function Livewire\str;
 
 class EquipmentItemTable extends DataTableComponent
 {
@@ -22,7 +25,8 @@ class EquipmentItemTable extends DataTableComponent
             Column::make("Product Code and Brand"),
             Column::make("Quantity", 'quantity')
                 ->sortable(),
-            Column::make("Category"),
+            Column::make("Category", 'equipment_type_id')
+                ->sortable(),
             Column::make("Price (LKR)", 'price')
                 ->sortable(),
             Column::make("Dimensions(cm) WxLxH"),
@@ -34,7 +38,27 @@ class EquipmentItemTable extends DataTableComponent
 
     public function query(): Builder
     {
-        return EquipmentItem::query();
+        return EquipmentItem::query()
+            ->when($this->getFilter('category'), fn($query, $category) => $query->where('equipment_type_id', $category));
+    }
+
+    public function filters(): array
+    {
+        // Category ------------------------------------------------------
+        $categoriesFromDB = EquipmentType::pluck('title','id')->toArray();
+
+        // Add '' => "Any" to the beginning of the array
+        $categories = array();
+        $categories[''] = "Any";
+        foreach ($categoriesFromDB as $key => $value) {
+            $categories[$key] = $value;
+        }
+
+
+        return [
+            'category' => Filter::make('Category')
+                ->select($categories)
+        ];
     }
 
     public function rowView(): string

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
                 "@coreui/coreui": "^3.0.0",
                 "@coreui/icons": "^1.0.1",
                 "@fortawesome/fontawesome-free": "^5.12.1",
+                "bootstrap": "^5.0.1",
                 "font-awesome": "^4.7.0",
                 "mix": "^0.0.1",
                 "urix": "^0.1.0"

--- a/resources/views/backend/equipment/items/index-table-row.blade.php
+++ b/resources/views/backend/equipment/items/index-table-row.blade.php
@@ -1,0 +1,59 @@
+<x-livewire-tables::table.cell>
+    {{$row->inventoryCode() }}
+</x-livewire-tables::table.cell>
+
+<x-livewire-tables::table.cell>
+    {{ $row->title }}
+</x-livewire-tables::table.cell>
+
+<x-livewire-tables::table.cell>
+    {{ $row->productCode ?? 'N/A' }} <br>({{ $row->brand ?? 'N/A' }})
+</x-livewire-tables::table.cell>
+
+<x-livewire-tables::table.cell>
+    {{ $row->quantity }}
+</x-livewire-tables::table.cell>
+
+<x-livewire-tables::table.cell>
+    @if($row->equipment_type() != null)
+        <a href="{{ route('admin.equipment.types.show', $row->equipment_type) }}">
+            {{ $row->equipment_type['title'] }}
+        </a>
+    @endif
+</x-livewire-tables::table.cell>
+
+<x-livewire-tables::table.cell>
+        {{ $row->price }}
+</x-livewire-tables::table.cell>
+
+<x-livewire-tables::table.cell>
+    {{ $row->width }} x {{ $row->height }} x {{ $row->length }}
+</x-livewire-tables::table.cell>
+
+<x-livewire-tables::table.cell>
+    {{ $row->weight }}
+</x-livewire-tables::table.cell>
+
+<x-livewire-tables::table.cell>
+        <div class="d-flex px-0 mt-0 mb-0">
+                <div class="btn-group" role="group" aria-label="Basic example">
+                        <a href="{{ route('admin.equipment.items.show', $row)}}"
+                           class="btn btn-secondary btn-xs"><i class="fa fa-eye" title="Show"></i>
+                        </a>
+
+                        <a href="{{ route('admin.equipment.items.edit', $row)}}"
+                           class="btn btn-info btn-xs"><i class="fa fa-pencil" title="Edit"></i>
+                        </a>
+                        <a href="{{ route('admin.equipment.items.edit.location', $row)}}"
+                           class="btn btn-warning btn-xs"><i class="fa fa-map-marker" title="Edit Location"></i>
+                        </a>
+                        <a href="{{ route('admin.equipment.items.delete', $row)}}"
+                           class="btn btn-danger btn-xs"><i class="fa fa-trash"
+                                                            title="Delete"></i>
+                        </a>
+                </div>
+        </div>
+</x-livewire-tables::table.cell>
+
+
+

--- a/resources/views/backend/equipment/items/index.blade.php
+++ b/resources/views/backend/equipment/items/index.blade.php
@@ -4,7 +4,7 @@
 
 @section('breadcrumb-links')
     @include('backend.equipment.includes.breadcrumb-links')
-@endsection 
+@endsection
 
 @section('content')
     <div>
@@ -35,64 +35,66 @@
                 @endif
 
                 <div class="container table-responsive pt-3">
-                    <table class="table table-striped">
-                        <tr>
-                            <th>Code</th>
-                            <th>Title</th>
-                            <th>Product Code<br/>and Brand</th>
-                            <th>Quantity</th>
-                            <th>Category</th>
-                            <th>Price (LKR)</th>
-                            <th>Dimensions(cm)<br/>W x L x H</th>
-                            <th>Weight (g)</th>
-                            <th>&nbsp;</th>
-                        </tr>
-                        
-                        @foreach($equipment as $eq)
-                            <tr>
-                                <td>{{ $eq->inventoryCode()  }}</td>
-                                <td>{{ $eq->title  }}</td>
-                                <td>{{ $eq->productCode ?? 'N/A' }} ({{ $eq->brand ?? 'N/A' }})</td>
-                                <td>{{ $eq->quantity }}</td>
-                                <td>
-                                    @if($eq->equipment_type() != null)
-                                        <a href="{{ route('admin.equipment.types.show', $eq->equipment_type) }}">
-                                            {{ $eq->equipment_type['title'] }}
-                                        </a>
-                                    @endif
-                                </td>
-                                <td>{{ $eq->price }}</td>
-                                <td>{{ $eq->width }} x {{ $eq->height }} x {{ $eq->length }}</td>
-                                <td>{{ $eq->weight }}</td>
+                    <livewire:backend.equipment-item-table/>
+                    {{--                    <table class="table table-striped">--}}
+                    {{--                        <tr>--}}
+                    {{--                            <th>Code</th>--}}
+                    {{--                            <th>Title</th>--}}
+                    {{--                            <th>Product Code<br/>and Brand</th>--}}
+                    {{--                            <th>Quantity</th>--}}
+                    {{--                            <th>Category</th>--}}
+                    {{--                            <th>Price (LKR)</th>--}}
+                    {{--                            <th>Dimensions(cm)<br/>W x L x H</th>--}}
+                    {{--                            <th>Weight (g)</th>--}}
+                    {{--                            <th>&nbsp;</th>--}}
+                    {{--                        </tr>--}}
 
-                                <td>
-                                    <div class="d-flex px-0 mt-0 mb-0">
-                                        <div class="btn-group" role="group" aria-label="Basic example">
-                                            <a href="{{ route('admin.equipment.items.show', $eq)}}"
-                                               class="btn btn-secondary btn-xs"><i class="fa fa-eye" title="Show"></i>
-                                            </a>
+                    {{--                        @foreach($equipment as $eq)--}}
+                    {{--                            <tr>--}}
+                    {{--                                <td>{{ $eq->inventoryCode()  }}</td>--}}
+                    {{--                                <td>{{ $eq->title  }}</td>--}}
+                    {{--                                <td>{{ $eq->productCode ?? 'N/A' }} ({{ $eq->brand ?? 'N/A' }})</td>--}}
+                    {{--                                <td>{{ $eq->quantity }}</td>--}}
+                    {{--                                <td>--}}
+                    {{--                                    @if($eq->equipment_type() != null)--}}
+                    {{--                                        <a href="{{ route('admin.equipment.types.show', $eq->equipment_type) }}">--}}
+                    {{--                                            {{ $eq->equipment_type['title'] }}--}}
+                    {{--                                        </a>--}}
+                    {{--                                    @endif--}}
+                    {{--                                </td>--}}
+                    {{--                                <td>{{ $eq->price }}</td>--}}
+                    {{--                                <td>{{ $eq->width }} x {{ $eq->height }} x {{ $eq->length }}</td>--}}
+                    {{--                                <td>{{ $eq->weight }}</td>--}}
 
-                                            <a href="{{ route('admin.equipment.items.edit', $eq)}}"
-                                               class="btn btn-info btn-xs"><i class="fa fa-pencil" title="Edit"></i>
-                                            </a>
-                                            <a href="{{ route('admin.equipment.items.edit.location', $eq)}}"
-                                               class="btn btn-warning btn-xs"><i class="fa fa-map-marker" title="Edit Location"></i>
-                                            </a>
-                                            <a href="{{ route('admin.equipment.items.delete', $eq)}}"
-                                               class="btn btn-danger btn-xs"><i class="fa fa-trash"
-                                                                                title="Delete"></i>
-                                            </a>
-                                        </div>
-                                    </div>
-                                </td>
+                    {{--                                <td>--}}
+                    {{--                                    <div class="d-flex px-0 mt-0 mb-0">--}}
+                    {{--                                        <div class="btn-group" role="group" aria-label="Basic example">--}}
+                    {{--                                            <a href="{{ route('admin.equipment.items.show', $eq)}}"--}}
+                    {{--                                               class="btn btn-secondary btn-xs"><i class="fa fa-eye" title="Show"></i>--}}
+                    {{--                                            </a>--}}
 
-                            </tr>
-                        @endforeach
-                    </table>
+                    {{--                                            <a href="{{ route('admin.equipment.items.edit', $eq)}}"--}}
+                    {{--                                               class="btn btn-info btn-xs"><i class="fa fa-pencil" title="Edit"></i>--}}
+                    {{--                                            </a>--}}
+                    {{--                                            <a href="{{ route('admin.equipment.items.edit.location', $eq)}}"--}}
+                    {{--                                               class="btn btn-warning btn-xs"><i class="fa fa-map-marker" title="Edit Location"></i>--}}
+                    {{--                                            </a>--}}
+                    {{--                                            <a href="{{ route('admin.equipment.items.delete', $eq)}}"--}}
+                    {{--                                               class="btn btn-danger btn-xs"><i class="fa fa-trash"--}}
+                    {{--                                                                                title="Delete"></i>--}}
+                    {{--                                            </a>--}}
+                    {{--                                        </div>--}}
+                    {{--                                    </div>--}}
+                    {{--                                </td>--}}
 
-                    {{ $equipment->links() }}
+                    {{--                            </tr>--}}
+                    {{--                        @endforeach--}}
+                    {{--                    </table>--}}
+
+                    {{--                    {{ $equipment->links() }}--}}
                 </div>
             </x-slot>
+
         </x-backend.card>
     </div>
 @endsection


### PR DESCRIPTION
Existing,
![image](https://user-images.githubusercontent.com/73381996/178286321-d55e7402-c413-4dab-966d-04cc0d1be281.png)

New,
![image](https://user-images.githubusercontent.com/73381996/178306220-7cd8ccb7-2ac2-4669-95b9-6778b8e371db.png)

Added Features,
- Search by name
- Sort by columns
-  Filter by category

@NuwanJ should I implement this to all the other tables as well ?
